### PR TITLE
Setting to show coaches (default) or leaders

### DIFF
--- a/includes/admin/admin-general.php
+++ b/includes/admin/admin-general.php
@@ -36,6 +36,7 @@ class DT_Genmapper_Tab_General
         $show_health_icons = get_option( 'dt_genmapper_show_health_icons', true );
         $show_health_metrics = get_option( 'dt_genmapper_show_health_metrics', false );
         $collapse_health_metrics_fields = get_option( 'dt_genmapper_collapse_metrics', true );
+        $connection_display = get_option( 'dt_genmapper_connection_display', 'coach' );
         $nonce = wp_create_nonce( static::class );
         include DT_Genmapper_Metrics::includes_dir() . 'template-admin-general.php';
     }
@@ -63,5 +64,8 @@ class DT_Genmapper_Tab_General
         } else {
             update_option( 'dt_genmapper_collapse_metrics', !empty( $_POST["dt_genmapper_collapse_metrics"] ) );
         }
+
+        $connection_display = ( isset( $_POST["dt_genmapper_connection_display"] ) && $_POST["dt_genmapper_connection_display"] === 'leaders' ) ? 'leaders' : 'coach';
+        update_option( 'dt_genmapper_connection_display', $connection_display );
     }
 }

--- a/includes/queries.php
+++ b/includes/queries.php
@@ -28,6 +28,11 @@ class DT_Genmapper_Plugin_Queries
         global $wpdb;
         $query = [];
 
+        // The "coach" column is populated from either the connected coach or the
+        // group's leaders (comma separated), depending on the plugin setting.
+        $connection_display = get_option( 'dt_genmapper_connection_display', 'coach' );
+        $connection_type = $connection_display === 'leaders' ? 'groups_to_leaders' : 'groups_to_coaches';
+
         switch ($query_name) {
             case 'multiplying_groups_only':
                 $query = $wpdb->get_results("
@@ -37,7 +42,12 @@ class DT_Genmapper_Plugin_Queries
                       a.post_title as name,
                       gs1.meta_value as group_status,
                       type1.meta_value as group_type,
-                      coach1.post_title as coach,
+                      (SELECT GROUP_CONCAT(leaders1.post_title SEPARATOR ', ')
+                        FROM $wpdb->p2p as groupleader1
+                        INNER JOIN $wpdb->posts as leaders1
+                          ON leaders1.ID=groupleader1.p2p_to
+                        WHERE groupleader1.p2p_from=a.ID
+                          AND groupleader1.p2p_type = '$connection_type') as coach,
                       location1.name as location_name,
                       (SELECT label FROM $wpdb->dt_location_grid_meta WHERE post_id = a.ID ORDER BY grid_meta_id DESC LIMIT 1) as location_meta_label,
                       startdate1.meta_value as start_date,
@@ -77,11 +87,6 @@ class DT_Genmapper_Plugin_Queries
                     LEFT JOIN $wpdb->postmeta as type1
                       ON type1.post_id=a.ID
                       AND type1.meta_key = 'group_type'
-                    LEFT JOIN $wpdb->p2p as groupcoach1
-                      ON groupcoach1.p2p_from=a.ID
-                      AND groupcoach1.p2p_type = 'groups_to_coaches'
-                    LEFT JOIN $wpdb->posts as coach1
-                      ON coach1.ID=groupcoach1.p2p_to
                     LEFT JOIN $wpdb->postmeta as grouplocation1
                       ON grouplocation1.post_id=a.ID
                       AND grouplocation1.meta_key = 'location_grid'
@@ -114,7 +119,12 @@ class DT_Genmapper_Plugin_Queries
                       (SELECT sub.post_title FROM $wpdb->posts as sub WHERE sub.ID = p.p2p_from ) as name,
                       (SELECT gsmeta.meta_value FROM $wpdb->postmeta as gsmeta WHERE gsmeta.post_id = p.p2p_from AND gsmeta.meta_key = 'group_status' LIMIT 1 ) as group_status,
                       (SELECT gsmeta.meta_value FROM $wpdb->postmeta as gsmeta WHERE gsmeta.post_id = p.p2p_from AND gsmeta.meta_key = 'group_type' LIMIT 1 ) as group_type,
-                      gcoach1.post_title as coach,
+                      (SELECT GROUP_CONCAT(gleaders1.post_title SEPARATOR ', ')
+                        FROM $wpdb->p2p as ggroupleader1
+                        INNER JOIN $wpdb->posts as gleaders1
+                          ON gleaders1.ID=ggroupleader1.p2p_to
+                        WHERE ggroupleader1.p2p_from=p.p2p_from
+                          AND ggroupleader1.p2p_type = '$connection_type') as coach,
                       glocation1.name as location,
                       (SELECT label FROM $wpdb->dt_location_grid_meta WHERE post_id = p.p2p_from ORDER BY grid_meta_id DESC LIMIT 1) as location_meta_label,
                       gstartdate1.meta_value as start_date,
@@ -147,11 +157,6 @@ class DT_Genmapper_Plugin_Queries
                     LEFT JOIN $wpdb->postmeta as gbaptized2
                       ON gbaptized2.post_id=p.p2p_from
                       AND gbaptized2.meta_key = 'baptized_in_group_count'
-                    LEFT JOIN $wpdb->p2p as ggroupcoach1
-                      ON ggroupcoach1.p2p_from=p.p2p_from
-                      AND ggroupcoach1.p2p_type = 'groups_to_coaches'
-                    LEFT JOIN $wpdb->posts as gcoach1
-                      ON gcoach1.ID=ggroupcoach1.p2p_to
                     LEFT JOIN $wpdb->postmeta as ggrouplocation1
                       ON ggrouplocation1.post_id=p.p2p_from
                       AND ggrouplocation1.meta_key = 'location_grid'

--- a/includes/template-admin-general.php
+++ b/includes/template-admin-general.php
@@ -51,6 +51,22 @@
                             </p>
                         </td>
                     </tr>
+                    <tr>
+                        <td>
+                            <label for="genmapper-connection-display">
+                                <b><?php esc_html_e( 'Show on group circles', 'disciple-tools-genmapper' )?></b>
+                            </label>
+                        </td>
+                        <td>
+                            <select name="dt_genmapper_connection_display" id="genmapper-connection-display">
+                                <option value="coach" <?php selected( $connection_display, 'coach' ); ?>><?php esc_html_e( 'Coach', 'disciple-tools-genmapper' ) ?></option>
+                                <option value="leaders" <?php selected( $connection_display, 'leaders' ); ?>><?php esc_html_e( 'Group Leaders', 'disciple-tools-genmapper' ) ?></option>
+                            </select>
+                            <p>
+                                <?php esc_html_e( 'Controls whether the group circles display the connected coaches or the group leaders.', 'disciple-tools-genmapper' ) ?>
+                            </p>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
             <input class="button hollow" type="submit" value="Save" />


### PR DESCRIPTION
I had a request to add a setting to show leader names instead of coach names in the Group Generation Tree. I thought a PR would be helpful if the community would like this setting as well. 